### PR TITLE
First fi_av_lookup should expect -FI_ETOOSMALL when attempting to retrie...

### DIFF
--- a/unit/av_test2.c
+++ b/unit/av_test2.c
@@ -142,7 +142,7 @@ av_test_sync(enum fi_av_type type, int count, uint64_t flags)
 	 */
 
 	ret = fi_av_lookup(av, remote_fi_addr, test_name_addr, &test_addrlen);
-	if (ret != FI_SUCCESS) {
+	if (ret != -FI_ETOOSMALL) {
 		fprintf(stderr,"fi_av_lookup %d: %s\n", ret, fi_strerror(-ret));
 		goto err;
 	}


### PR DESCRIPTION
...ve correct size for buffer.

@hppritcha this is the only problem I found with your test. When I run it now it is silent so I'm assuming that means my implementation passes everything. Is that correct?

Signed-off-by: Ben Turrubiates bturrubiates@lanl.gov
